### PR TITLE
IComparable constraint for name type

### DIFF
--- a/src/systems.cs
+++ b/src/systems.cs
@@ -20,7 +20,7 @@ namespace Leopotam.EcsLite.ExtendedSystems {
         public bool State {get; set;}
     }
 
-    internal interface IEcsGroupSystemState<T> where T: IComparable {
+    public interface IEcsGroupSystemState<T> where T: IComparable {
         public T Name {get; set;}
         public bool State {get; set;}
     }
@@ -70,7 +70,7 @@ namespace Leopotam.EcsLite.ExtendedSystems {
     [Il2CppSetOption (Option.NullChecks, false)]
     [Il2CppSetOption (Option.ArrayBoundsChecks, false)]
 #endif
-    internal class EcsGroupSystem<TName, TState> :
+    public sealed class EcsGroupSystem<TName, TState> :
         IEcsPreInitSystem,
         IEcsInitSystem,
         IEcsRunSystem,
@@ -134,7 +134,7 @@ namespace Leopotam.EcsLite.ExtendedSystems {
         public void Run (EcsSystems systems) {
             foreach (var entity in _filter) {
                 ref var evt = ref _pool.Get (entity);
-                if (evt.Name.Equals (_name)) {
+                if (evt.Name.CompareTo (_name) == 0) {
                     _state = evt.State;
                     _pool.Del (entity);
                 }

--- a/src/systems.cs
+++ b/src/systems.cs
@@ -4,8 +4,8 @@
 // Copyright (c) 2021-2022 Leopotam <leopotam@gmail.com>
 // -------------------------------------------------------------------------------------
 
-#if ENABLE_IL2CPP
 using System;
+#if ENABLE_IL2CPP
 using Unity.IL2CPP.CompilerServices;
 #endif
 
@@ -20,12 +20,12 @@ namespace Leopotam.EcsLite.ExtendedSystems {
     [Il2CppSetOption (Option.ArrayBoundsChecks, false)]
 #endif
     public static class Extensions {
-        public static EcsSystems AddGroup<T> (this EcsSystems systems, T groupName, bool defaultState, string eventWorldName, params IEcsSystem[] nestedSystems) where T: System.IComparable, IEquatable<T> {
+        public static EcsSystems AddGroup<T> (this EcsSystems systems, T groupName, bool defaultState, string eventWorldName, params IEcsSystem[] nestedSystems) where T: IComparable {
             return systems.Add (new EcsGroupSystem<T> (groupName, defaultState, eventWorldName, nestedSystems));
         }
 
         public static EcsSystems AddGroup (this EcsSystems systems, string groupName, bool defaultState, string eventWorldName, params IEcsSystem[] nestedSystems) {
-            return systems.AddGroup<string>(groupName, defaultState, eventWorldName);
+            return systems.AddGroup<string>(groupName, defaultState, eventWorldName, nestedSystems);
         }
 
         public static EcsSystems DelHere<T> (this EcsSystems systems, string worldName = null) where T : struct {
@@ -66,7 +66,7 @@ namespace Leopotam.EcsLite.ExtendedSystems {
         IEcsRunSystem,
         IEcsDestroySystem,
         IEcsPostDestroySystem
-        where T: System.IComparable, IEquatable<T> {
+        where T: IComparable {
         readonly IEcsSystem[] _allSystems;
         readonly IEcsRunSystem[] _runSystems;
         readonly int _runSystemsCount;

--- a/src/systems.cs
+++ b/src/systems.cs
@@ -10,7 +10,12 @@ using Unity.IL2CPP.CompilerServices;
 #endif
 
 namespace Leopotam.EcsLite.ExtendedSystems {
-    public struct EcsGroupSystemState<T> where T : System.IComparable {
+    public struct EcsGroupSystemState {
+        public string Name;
+        public bool State;
+    }
+
+    public struct EcsGroupSystemState<T> where T: System.IComparable {
         public T Name;
         public bool State;
     }
@@ -20,8 +25,12 @@ namespace Leopotam.EcsLite.ExtendedSystems {
     [Il2CppSetOption (Option.ArrayBoundsChecks, false)]
 #endif
     public static class Extensions {
-        public static EcsSystems AddGroup<T> (this EcsSystems systems, T groupName, bool defaultState, string eventWorldName, params IEcsSystem[] nestedSystems) where T : System.IComparable {
-            return systems.Add (new EcsGroupSystem<T>(groupName, defaultState, eventWorldName, nestedSystems));
+        public static EcsSystems AddGroup<T> (this EcsSystems systems, T groupName, bool defaultState, string eventWorldName, params IEcsSystem[] nestedSystems) where T: System.IComparable {
+            return systems.Add (new EcsGroupSystem<T> (groupName, defaultState, eventWorldName, nestedSystems));
+        }
+
+        public static EcsSystems AddGroup (this EcsSystems systems, string groupName, bool defaultState, string eventWorldName, params IEcsSystem[] nestedSystems) {
+            return systems.Add (new EcsGroupSystem<string> (groupName, defaultState, eventWorldName, nestedSystems));
         }
 
         public static EcsSystems DelHere<T> (this EcsSystems systems, string worldName = null) where T : struct {
@@ -61,15 +70,18 @@ namespace Leopotam.EcsLite.ExtendedSystems {
         IEcsInitSystem,
         IEcsRunSystem,
         IEcsDestroySystem,
-        IEcsPostDestroySystem 
-        where T : System.IComparable {
+        IEcsPostDestroySystem
+        where T: System.IComparable {
         readonly IEcsSystem[] _allSystems;
         readonly IEcsRunSystem[] _runSystems;
         readonly int _runSystemsCount;
         readonly string _eventsWorldName;
         readonly T _name;
+        readonly string _nameString;
         EcsFilter _filter;
+        EcsFilter _filterObsolete;
         EcsPool<EcsGroupSystemState<T>> _pool;
+        EcsPool<EcsGroupSystemState> _poolObsolete;
         bool _state;
 
         public EcsGroupSystem (T name, bool defaultState, string eventsWorldName, params IEcsSystem[] systems) {
@@ -78,6 +90,7 @@ namespace Leopotam.EcsLite.ExtendedSystems {
             if (systems == null || systems.Length == 0) { throw new System.Exception ("Systems list cant be null or empty."); }
 #endif
             _name = name;
+            _nameString = name.ToString ();
             _state = defaultState;
             _eventsWorldName = eventsWorldName;
             _allSystems = systems;
@@ -93,7 +106,9 @@ namespace Leopotam.EcsLite.ExtendedSystems {
         public void PreInit (EcsSystems systems) {
             var world = systems.GetWorld (_eventsWorldName);
             _pool = world.GetPool<EcsGroupSystemState<T>> ();
+            _poolObsolete = world.GetPool<EcsGroupSystemState> ();
             _filter = world.Filter<EcsGroupSystemState<T>> ().End ();
+            _filterObsolete = world.Filter<EcsGroupSystemState> ().End ();
             for (var i = 0; i < _allSystems.Length; i++) {
                 if (_allSystems[i] is IEcsPreInitSystem preInitSystem) {
                     preInitSystem.PreInit (systems);
@@ -118,11 +133,23 @@ namespace Leopotam.EcsLite.ExtendedSystems {
         }
 
         public void Run (EcsSystems systems) {
+            bool foundValidEvent = false;
+
             foreach (var entity in _filter) {
                 ref var evt = ref _pool.Get (entity);
                 if (evt.Name.Equals (_name)) {
                     _state = evt.State;
                     _pool.Del (entity);
+                    foundValidEvent = true;
+                }
+            }
+            if (!foundValidEvent) {
+                foreach (var entity in _filterObsolete) {
+                    ref var evt = ref _poolObsolete.Get (entity);
+                    if (evt.Name == _nameString) {
+                        _state = evt.State;
+                        _poolObsolete.Del (entity);
+                    }
                 }
             }
             if (_state) {


### PR DESCRIPTION
This allows users to not be restricted to only `string` types for group names. Anything that inherits `IComparable` would now be valid (e.g. numbers, enums, strings, etc).